### PR TITLE
Use short github url to avoid issues in environment with proxy server

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "array-flatten": "^1.0.2",
     "methods": "^1.1.1",
     "raml-path-match": "^1.1.0",
-    "router": "git://github.com/blakeembrey/router#router-engine"
+    "router": "blakeembrey/router#router-engine"
   },
   "devDependencies": {
     "chai": "^1.10.0",


### PR DESCRIPTION
Use short github url for `router` dependency instead of `git://` to avoid issues when in an environment where traffic needs to go through a proxy server e.g. squid.
