### PR TITLE
Use object shorthand for properties

### DIFF
--- a/test.js
+++ b/test.js
@@ -97,7 +97,7 @@ describe('Router', function () {
         }
 
         return makeFetcher(router).fetch('/', {
-          method: method
+          method
         })
           .then(function (res) {
             expect(res.status).to.equal(200)
@@ -153,7 +153,7 @@ describe('Router', function () {
         router[method]('/foo', helloWorld)
 
         return makeFetcher(router).fetch('/foo', {
-          method: method
+          method
         })
           .then(function (res) {
             expect(res.status).to.equal(200)
@@ -169,7 +169,7 @@ describe('Router', function () {
         router[method]('/foo', [helloWorld])
 
         return makeFetcher(router).fetch('/foo', {
-          method: method
+          method
         })
           .then(function (res) {
             expect(res.status).to.equal(200)
@@ -200,7 +200,7 @@ describe('Router', function () {
         })
 
         return makeFetcher(router).fetch('/123', {
-          method: method
+          method
         })
           .then(function (res) {
             expect(res.status).to.equal(200)


### PR DESCRIPTION
This rule is on its way into the latest Standard ☺️

ref: https://github.com/standard/eslint-config-standard/pull/166

Compatibility: This syntax is supported on Node.js >=4, this project are using `Array.isArray` which is supported on Node.js >= 6, so there should be no degradation ✅ 

(p.s. consider adding an [`engines`](https://docs.npmjs.com/files/package.json#engines) field to your package.json to indicated supported Node.js version)